### PR TITLE
Add support for interrupts

### DIFF
--- a/ports/gprs_a9/mpconfigport.h
+++ b/ports/gprs_a9/mpconfigport.h
@@ -249,6 +249,8 @@ typedef long mp_off_t;
 
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8]; \
+    mp_obj_t machine_pin_irq_handler[7]; \
+    mp_obj_t machine_pin_irq_handler_arg[7]; \
     byte *uart_rxbuf[2];
 
 #include "csdk_config.h"


### PR DESCRIPTION
* Interrupts are working normally. Only  IRQ types IRQ_RISING (2), IRQ_FALLING (3) and IRQ_RISING_FALLING (4) are working,   IRQ_HIGH and  IRQ_LOW in my tests halts the module and it stops working until reset. Did not test if it is counting the interrupts correctly, but seems right.

* Also added on() and off() to Pin.

I didn't added an code example because I didn't really understood how the numbering there works. But could be as follow:

```
from machine import Pin
from utime import sleep_ms

def callback(self):
    global irq_count
    irq_count = irq_count + 1

def callback_arg(n):
    global irq_count
    irq_count = irq_count + 1
    print(n + irq_count)

irq_count = 0
pirq = Pin(2, Pin.INT, Pin.PULL_UP)
irq = pirq.irq(trigger=Pin.IRQ_FALLING, handler=callback, debounce=200)
# irq = pirq.irq(trigger=3, handler=callback_arg, debounce=50, handler_arg=n)

while True:
    print(irq_count)
    sleep_ms(2000)
```